### PR TITLE
Initial support for error codes

### DIFF
--- a/examples/errors.py
+++ b/examples/errors.py
@@ -1,0 +1,22 @@
+from tranquilizer import tranquilize
+
+@tranquilize()
+def test(number: int):
+    '''testing types and errors
+
+    Let's see if we can find a reasonable way to express
+    execptions and return codes.
+
+    :raise ValueError: when number less than zero
+    :raises TypeError: just because
+    :param number: a positive integer
+    '''
+
+    if number < -1:
+        raise TypeError('just wrong')
+    elif number < 0:
+        raise ValueError('{} is not positive'.format(number))
+    elif number == 0:
+        number = 10 / number
+
+    return {'response':"{} received".format(number)}

--- a/examples/files.py
+++ b/examples/files.py
@@ -14,6 +14,7 @@ import numpy as np
 
 @tranquilize('post')
 def text_file(file: TextFile):
+    '''a text file'''
     return {'response':file.read()}
 
 @tranquilize('post')

--- a/examples/type_conversion.py
+++ b/examples/type_conversion.py
@@ -3,7 +3,9 @@ from tranquilizer.types import ParsedDateTime, TypedList
 
 @tranquilize(method='get')
 def dates(date: ParsedDateTime):
-    '''Extract components of a datetime string.'''
+    '''Extract components of a datetime string.
+    
+    :param date: parsible datetime'''
 
     response = {
             'month'  : date.month,
@@ -16,9 +18,11 @@ def dates(date: ParsedDateTime):
 
 @tranquilize(method='post')
 def vector_multiply(items: TypedList[float], factor: int = 10):
-    '''Multiply a list of floats by a factor'''
+    '''Multiply a list of floats by a factor
 
-    raise ValueError('nope', code=403)
+    :param items: list of floating point numbers
+    :param factor: multiplicative factor (default 10)'''
+
     new_items = [i * factor for i in items]
     response = {
             'items': new_items

--- a/tranquilizer/application.py
+++ b/tranquilizer/application.py
@@ -45,7 +45,7 @@ def make_app(functions, name, prefix='/'):
 
     @api.errorhandler
     def _default_error(error):
-        return {'message':str(error)}, 500
+        return {'message':repr(error)}, 500
 
     ns = Namespace(prefix, description='Tranquilized API')
 

--- a/tranquilizer/application.py
+++ b/tranquilizer/application.py
@@ -43,6 +43,10 @@ def make_app(functions, name, prefix='/'):
     app.config['PREFERRED_URL_SCHEME'] = 'https'
     app.wsgi_app = ProxyFix(app.wsgi_app)
 
+    @api.errorhandler
+    def _default_error(error):
+        return {'message':str(error)}, 500
+
     ns = Namespace(prefix, description='Tranquilized API')
 
     for f in functions:

--- a/tranquilizer/decorator.py
+++ b/tranquilizer/decorator.py
@@ -24,6 +24,9 @@ def _prepare_arg(arg):
 def _prepare_arg_docs(docstring):
     args = re.findall(PARAM_REGEX, docstring)
     remainder = re.sub(PARAM_REGEX, '', docstring)
+
+    if not args:
+        return {}, remainder
     
     docs = {}
     for arg in args:
@@ -63,8 +66,13 @@ def _prepare(fn):
     for k, v in sig.parameters.items():
         _args[k] = _prepare_arg(v)
 
-    param_docs, docstring = _prepare_arg_docs(fn.__doc__)
-    error_docs, docstring = _prepare_error_docs(docstring)
+    if fn.__doc__:
+        param_docs, docstring = _prepare_arg_docs(fn.__doc__)
+        error_docs, docstring = _prepare_error_docs(docstring)
+    else:
+        param_docs = {}
+        error_docs = {}
+        docstring = ''
 
     spec = {
         'name': fn.__name__,

--- a/tranquilizer/decorator.py
+++ b/tranquilizer/decorator.py
@@ -1,7 +1,10 @@
-import ast
-import json
 from inspect import signature
-from collections import Mapping, Sequence
+import re
+
+PARAM_REGEX = re.compile(":param (?P<name>[\*\w]+): (?P<doc>.*?)"
+                         "(?:(?=:param)|(?=:return)|(?=:raises)|\Z)", re.S)
+RAISE_REGEX = re.compile(":raise[s]? (?P<name>[\*\w]+): (?P<doc>.*?)"
+                         "(?:(?=:param)|(?=:return)|(?=:raise[s]?)|\Z)", re.S)
 
 def _prepare_arg(arg):
     '''Return a keyword arg spec (dict)'''
@@ -17,6 +20,27 @@ def _prepare_arg(arg):
         _arg['default'] = arg.default
 
     return _arg
+
+def _prepare_arg_docs(docstring):
+    args = re.findall(PARAM_REGEX, docstring)
+    remainder = re.sub(PARAM_REGEX, '', docstring)
+    
+    docs = {}
+    for arg in args:
+        docs[arg[0]] = arg[1].strip()
+
+    return docs, remainder
+
+def _prepare_error_docs(docstring):
+    errors = re.findall(RAISE_REGEX, docstring)
+    remainder = re.sub(RAISE_REGEX, '', docstring)
+
+    if errors:
+        messages = '\n'.join('{}:{}'.format(e,msg.strip()) for e,msg in errors)
+        responses = {500:messages}
+        return responses, remainder
+    
+    return None, remainder
 
 def _prepare(fn):
     """Inspects a function and return a function spec dict
@@ -39,11 +63,16 @@ def _prepare(fn):
     for k, v in sig.parameters.items():
         _args[k] = _prepare_arg(v)
 
+    param_docs, docstring = _prepare_arg_docs(fn.__doc__)
+    error_docs, docstring = _prepare_error_docs(docstring)
+
     spec = {
         'name': fn.__name__,
-        'docstring': fn.__doc__,
+        'docstring': docstring,
+        'args': _args,
+        'param_docs': param_docs,
+        'error_docs': error_docs
     }
-    spec['args'] = _args
 
     return spec
 
@@ -63,4 +92,3 @@ def tranquilize(method='get'):
         return f
 
     return _dart
-

--- a/tranquilizer/resource.py
+++ b/tranquilizer/resource.py
@@ -5,21 +5,19 @@ from collections import Mapping, Sequence
 
 from .types import is_container
 
+
 def _make_parser(func_spec, location='args'):
     '''Create RequestParser from anotated function arguments
 
     arguments without default values are flagged as required'''
 
-    parser = reqparse.RequestParser()
+    parser = reqparse.RequestParser(bundle_errors=True)
     for argument,spec in func_spec['args'].items():
         _type = spec.get('annotation', str)
         _default = spec.get('default', None)
         action = 'store'
 
-        try:
-            description = getattr(_type, '__description__')
-        except AttributeError:
-            description = None
+        doc = func_spec['param_docs'].get(argument, None)
 
         # Files (e.g., images) arrive in a different
         # Flask.Requst location. The last value in
@@ -34,14 +32,13 @@ def _make_parser(func_spec, location='args'):
             action = 'append'
             type_name = _type.__args__[0].__name__
             _type.__schema__ = {'type':type_name}
-            description = 'List of {}'.format(type_name)
 
         parser.add_argument(argument, type=_type,
                             default=_default,
                             required=(not _default),
                             location=_location,
                             action=action,
-                            help=description)
+                            help=doc)
 
     return parser
 
@@ -56,7 +53,11 @@ def make_resource(func, api):
         output = func(**request)
         return jsonify(output)
 
-    _method.__doc__ = func.__doc__
+    error_docs = func._spec['error_docs']
+    if error_docs:
+        _method = api.doc(responses = error_docs)(_method)
+
+    _method.__doc__ = func._spec['docstring']
 
     Tranquilized = type('Tranquilized', (Resource,), {func._method:_method})
 


### PR DESCRIPTION
@TomAugspurger,

Here's the first component to your suggestion of supporting errors.

1. All exceptions return error code 500 and the repr of the exception
2. `:raise` in docstring will add to the Responses swagger documentation. See `examples/errors.py`.

<img width="646" alt="screen shot 2018-08-08 at 2 31 03 pm" src="https://user-images.githubusercontent.com/43654/43856883-be2f2fa0-9b17-11e8-8421-7cf053452871.png">

Should a user prefer that an exception thrown by their function have a response code different from 500 how might you prefer to express that?
* in the docstring?
```
:raise ValueError: something bad happened, 404
```
* as an argument to `@tranquilize`?
```python
@tranquilize(responses={404:ValueError})
def ...
```