### PR TITLE
Allow Standard types

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,27 +67,35 @@ type function to transform the string to the requested data type. This avoids ha
 
 ## Data Types
 
-In addition to [*builtin* types](https://docs.python.org/3/library/stdtypes.html) Tranquilizer provides several new types in the `tranquilizer.types` module. 
+In addition to [*builtin* types](https://docs.python.org/3/library/stdtypes.html) Tranquilizer 
+provides specialized support for Lists, date/datetime, and files. 
+
 
 |Type|Description|
 |----|-----------|
-|`ParsedDateTime`| Converts string to `datetime.datetime` with `dateutil.parser.parse`.|
-|`TypedList[<type>]`| Converts *repeated* arguments to a list; each value is converted to `<type>`.|
+|`datetime.date` or `datetime.datetime`| Converts string with `dateutil.parser.parse` and returns specified type.|
+|`list`| Converts *repeated* arguments to a list of strings.|
+|`typing.List[<type>]`| Converts *repeated* arguments to a list; each value is converted to `<type>`.|
 
-`TypedList` arguments are constructed using the `action='append'` argument described in
+`List` arguments are constructed using the `action='append'` argument described in
 the [Flask RESTPlus documentation](http://flask-restplus.readthedocs.io/en/stable/parsing.html#multiple-values-lists).
-Any valid type can be used in `TypedList[]`.
+Any valid type can be used in `List[]`.
 
-The following types are subclasses of `tranquilizer.types.File`, which returns a [werkzeug `FileStorage`](http://werkzeug.pocoo.org/docs/0.14/datastructures/#werkzeug.datastructures.FileStorage).
+The following file-like types are handled by [werkzeug `FileStorage`](http://werkzeug.pocoo.org/docs/0.14/datastructures/#werkzeug.datastructures.FileStorage).
 `FileStorage` is a file-like object that supports methods like `.read()` and `.readlines()`.
 These types support sending files with cURL using `-F`.
 
 |Type|Description|
 |----|-----------|
-|`File`| File-like object to read binary data.|
-|`TextFile`| Converts `File` type to `io.StringIO()`.|
-|`Image`| Converts `File` type to `PIL.Image`.|
-|`NDArray`| Converts `File` type to NumPy array using `np.load()`. |
+|`typing.BinaryIO`| File-like object to read binary data.|
+|`typing.TextIO`| Converts `FileStorage` type to `io.StringIO()`.|
+
+Further, specific support for Image and NumPy files are provided. The binary contents of the file are automatically converted.
+
+|Type|Description|
+|----|-----------|
+|`PIL.Image.Image`| Converts `FileStorage` type to PIL Image.|
+|`numpy.ndarray`| Converts `FileStorage` type to NumPy array using `np.load()`. |
 
 ### Custom types
 
@@ -95,8 +103,8 @@ Custom type classes can be built...
 
 ## Type hints example
 
-The example below uses `int`, `ParsedDateTime`, and `TypedList`. `ParsedDataTime`
-has been built with `datetutil` and will convert any compatible datetime string to a `datetime.datetime` object. `TypedList`
+The example below uses `int`, `datetime.datetime`, and `typing.List`. `datetime.datetime` support
+has been built with `datetutil` and will convert any compatible datetime string to a `datetime.datetime` object. `typing.List`
 supports specialization with `[]` and will transform all *repeated* arguments passed to the REST API into a list and convert
 the type of each element.
 
@@ -104,10 +112,11 @@ Finally, tranquilizer supports default arguments.
 
 ```python
 from tranquilizer import tranquilize
-from tranquilizer.types import ParsedDateTime, TypedList
+from datetime import date
+from typing import List
 
 @tranquilize(method='post')
-def convert(string: str, date: ParsedDateTime, items: TypedList[float], factor: int = 10):
+def convert(string: str, date: date, items: List[float], factor: int = 10):
     '''Let's convert strings to something useful'''
 
     new_items = [i * factor for i in items]
@@ -138,8 +147,3 @@ Out[4]:
 
 In [5]:
 ```
-
-Types defined by tranquilizer will include the description of how the data will be converted.
-
-![](img/types.png)
-

--- a/examples/files.py
+++ b/examples/files.py
@@ -9,13 +9,13 @@
 # requests.post('http://localhost:8086/array_file', files={'arr':f.getvalue()})
 
 from tranquilizer import tranquilize
-from tranquilizer.types import TextFile, NDArray
+from typing import TextIO
 import numpy as np
 
 @tranquilize('post')
-def text_file(file: TextFile):
+def text_file(file: TextIO):
     return {'response':file.read()}
 
 @tranquilize('post')
-def array_file(arr: NDArray):
+def array_file(arr: np.ndarray):
     return {'response':(arr.shape, str(arr.dtype))}

--- a/examples/images.py
+++ b/examples/images.py
@@ -3,7 +3,7 @@
 # requests.post('http://localhost:8086/describe_image', files={'image':open('<image-file>', 'rb')})
 
 from tranquilizer import tranquilize
-from tranquilizer.types import Image
+from PIL.Image import Image
 import numpy as np
 
 @tranquilize(method='post')

--- a/examples/type_conversion.py
+++ b/examples/type_conversion.py
@@ -1,9 +1,10 @@
 from tranquilizer import tranquilize
-from tranquilizer.types import ParsedDateTime, TypedList
+from typing import List
+from datetime import date
 
 @tranquilize(method='get')
-def dates(date: ParsedDateTime):
-    '''Extract components of a datetime string.'''
+def dates(date: date):
+    '''Extract components of a date string.'''
 
     response = {
             'month'  : date.month,
@@ -15,10 +16,9 @@ def dates(date: ParsedDateTime):
     return response
 
 @tranquilize(method='post')
-def vector_multiply(items: TypedList[float], factor: int = 10):
+def vector_multiply(items: List[float], factor: int = 10):
     '''Multiply a list of floats by a factor'''
 
-    raise ValueError('nope', code=403)
     new_items = [i * factor for i in items]
     response = {
             'items': new_items

--- a/tranquilizer/__init__.py
+++ b/tranquilizer/__init__.py
@@ -1,5 +1,4 @@
 '''Tranquilizer'''
 from .decorator import tranquilize
-from . import types
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'

--- a/tranquilizer/resource.py
+++ b/tranquilizer/resource.py
@@ -3,7 +3,7 @@ from flask import jsonify, request
 from flask_restplus import Resource, reqparse
 from collections import Mapping, Sequence
 
-from .types import is_container
+from .types import is_container, type_mapper
 
 def _make_parser(func_spec, location='args'):
     '''Create RequestParser from anotated function arguments
@@ -29,6 +29,8 @@ def _make_parser(func_spec, location='args'):
             _location = (location, _loc)
         except AttributeError:
             _location = location
+
+        _type = type_mapper(_type)
 
         if is_container(_type):
             action = 'append'

--- a/tranquilizer/resource.py
+++ b/tranquilizer/resource.py
@@ -16,6 +16,8 @@ def _make_parser(func_spec, location='args'):
         _default = spec.get('default', None)
         action = 'store'
 
+        _type = type_mapper(_type)
+
         try:
             description = getattr(_type, '__description__')
         except AttributeError:
@@ -30,7 +32,6 @@ def _make_parser(func_spec, location='args'):
         except AttributeError:
             _location = location
 
-        _type = type_mapper(_type)
 
         if is_container(_type):
             action = 'append'

--- a/tranquilizer/types.py
+++ b/tranquilizer/types.py
@@ -1,7 +1,7 @@
 from collections import Mapping, Sequence
 from dateutil.parser import parse
-from datetime import datetime
-from typing import List, Generic, TypeVar
+from datetime import datetime, date
+from typing import List, Generic, TypeVar, TextIO, BinaryIO
 from werkzeug.datastructures import FileStorage
 from PIL import Image as pil_image
 import numpy as np
@@ -91,3 +91,21 @@ class TypedList(List, Generic[T]):
     def __new__(cls, *args, **kwds):
         _type = cls.__args__[0]
         return _type(*args)
+
+
+def type_mapper(type_):
+    if issubclass(type_, List):
+        item_type = type_.__args__[0]
+        return TypedList[item_type]
+    elif issubclass(type_, TextIO):
+        return TextFile
+    elif issubclass(type_, BinaryIO):
+        return File
+    elif issubclass(type_, pil_image):
+        return Image
+    elif issubclass(type_, np.ndarray):
+        return NDArray
+    elif issubclass(type_, [datetime, date]):
+        return ParsedDateTime
+    else:
+        return type_

--- a/tranquilizer/types.py
+++ b/tranquilizer/types.py
@@ -7,10 +7,6 @@ from PIL import Image as pil_image
 import numpy as np
 import io
 
-__all__ = ['File', 'TextFile', 'Image', 'NDArray',
-           'ParsedDateTime', 'TypedList'
-]
-
 T = TypeVar('T')
 S = TypeVar('S')
 
@@ -61,21 +57,27 @@ class NDArray(File):
         return np.load(f)
 
 
-class ParsedDateTime(datetime):
+class ParsedDateTime(Generic[T]):
     '''A flexible dateteime.datetime class
 
-    If the constructor
-
     recieves a string: use dateutil to parse
-    receives an integer: use datetime.datetime'''
+    
+    The type specifier determines the returned type.
+    ParsedDateTime[datetime.date]
+    ParsedDateTime[datetime.datetime]
+    ParsedDateTime[pd.Timestamp]
+    '''
     __schema__ = {'type':'string', 'format':'date-time'}
     __description__ = 'dateutil.parser.parse compatible datetime string'
 
     def __new__(cls, *args):
-        if isinstance(args[0], str) and len(args)==1:
-            return parse(args[0])
+        parsed =  parse(args[0])
+        _type = cls.__args__[0]
+        if issubclass(_type, date):
+            return parsed.date()
         else:
-            return super().__new__(datetime, *args)
+            return _type(parsed)
+        return parsed
 
 
 class TypedList(List, Generic[T]):
@@ -94,18 +96,27 @@ class TypedList(List, Generic[T]):
 
 
 def type_mapper(type_):
+    '''Map common type hints to custom classes
+    
+    If no conversion is necessary the input type
+    is returned.
+    '''
+
     if issubclass(type_, List):
-        item_type = type_.__args__[0]
+        try:
+            item_type = type_.__args__[0]
+        except:
+            item_type = str
         return TypedList[item_type]
     elif issubclass(type_, TextIO):
         return TextFile
     elif issubclass(type_, BinaryIO):
         return File
-    elif issubclass(type_, pil_image):
+    elif issubclass(type_, pil_image.Image):
         return Image
     elif issubclass(type_, np.ndarray):
         return NDArray
-    elif issubclass(type_, [datetime, date]):
-        return ParsedDateTime
+    elif issubclass(type_, (datetime, date)):
+        return ParsedDateTime[type_]
     else:
         return type_


### PR DESCRIPTION
@mrocklin and @seibert

This addresses #4 to support the standard types `typing.List`, `datetime.date/datetime`, `typing.BinaryIO`, `typing.TextIO`, `PIL.Image.Image`, and `np.ndarray`.

The internal Tranquilizer types have been removed from the README and examples. The `types` module is also hidden from `import` and not recommended for end-users.

Can you recommend other common datatypes? I'm specifically interested in those that cannot easily convert a string that would be provided in the response body.