### PR TITLE
Support Jupyter Notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.0] - 2019-01-23
+## Added
+- Support serving from Jupyter Notebooks
+
 ## [0.1.2] - 2018-12-29
 ### Added
 - Customize application name in Swagger with `--name`

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Other methods are under consideration.
 By default a *tranquilized* function will receive all inputs as strings. This behavior can be modified by using [type hints](https://docs.python.org/3/library/typing.html). When data is received by the Flask server it will use the provided
 type function to transform the string to the requested data type. This avoids having to perform the conversion in your *tranquilized* function.
 
+## Supported source formats
+
+Tranquilizer can serve functions written in Python source (`.py`) files or Jupyter Notebooks (`.ipynb`).
+Note that all calls to [Jupyter Magic](https://ipython.readthedocs.io/en/stable/interactive/magics.html)
+and Shell (`!`) commands will be ignored. Only those lines will be ignored, the rest of the cell will continue to run.
+
 ## Data Types
 
 In addition to [*builtin* types](https://docs.python.org/3/library/stdtypes.html) Tranquilizer 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ type function to transform the string to the requested data type. This avoids ha
 ## Supported source formats
 
 Tranquilizer can serve functions written in Python source (`.py`) files or Jupyter Notebooks (`.ipynb`).
+
+When working interactively in Jupyter Notebooks the decorated functions will continue to operate as normal.
 Note that all calls to [Jupyter Magic](https://ipython.readthedocs.io/en/stable/interactive/magics.html)
-and Shell (`!`) commands will be ignored. Only those lines will be ignored, the rest of the cell will continue to run.
+and Shell (`!`) commands will be ignored when the REST API is served.
+Only those lines will be ignored, the rest of the cell will continue to run.
 
 ## Data Types
 

--- a/examples/cheese_shop.ipynb
+++ b/examples/cheese_shop.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = !ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,6 +30,72 @@
     "\n",
     "    :param cheese: What cheese would you like?'''\n",
     "    return {'response':\"I'm afraid we're fresh out of {}, Sir.\".format(cheese)}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'response': \"I'm afraid we're fresh out of cheddar, Sir.\"}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "order('cheddar')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'get'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "order._method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'order',\n",
+       " 'docstring': \"I'd like to buy some cheese!\\n\\n    \",\n",
+       " 'args': {'cheese': {'name': 'cheese'}},\n",
+       " 'param_docs': {'cheese': 'What cheese would you like?'},\n",
+       " 'error_docs': None}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "order._spec"
    ]
   }
  ],

--- a/examples/cheese_shop.ipynb
+++ b/examples/cheese_shop.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tranquilizer import tranquilize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tranquilize()\n",
+    "def order(cheese):\n",
+    "    '''I'd like to buy some cheese!\n",
+    "\n",
+    "    :param cheese: What cheese would you like?'''\n",
+    "    return {'response':\"I'm afraid we're fresh out of {}, Sir.\".format(cheese)}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:tranq]",
+   "language": "python",
+   "name": "conda-env-tranq-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/cheese_shop.ipynb
+++ b/examples/cheese_shop.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,16 +11,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.37 ms, sys: 6.08 ms, total: 8.45 ms\n",
+      "Wall time: 21 ms\n"
+     ]
+    }
+   ],
    "source": [
-    "output = !ls"
+    "%%time\n",
+    "\n",
+    "output = !ls\n",
+    "output"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,14 +42,15 @@
     "\n",
     "    :param cheese: What cheese would you like?'''\n",
     "    \n",
-    "    time = %timeit -o import random\n",
+    "    time = %timeit -oq import random\n",
+    "    print(time)\n",
     "    \n",
     "    return {'response':\"I'm afraid we're fresh out of {}, Sir.\".format(cheese)}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
@@ -46,7 +59,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "89.6 ns ± 0.528 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)\n"
+      "102 ns ± 11.6 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)\n"
      ]
     },
     {
@@ -55,7 +68,7 @@
        "{'response': \"I'm afraid we're fresh out of cheddar, Sir.\"}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/cheese_shop.ipynb
+++ b/examples/cheese_shop.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,23 +29,33 @@
     "    '''I'd like to buy some cheese!\n",
     "\n",
     "    :param cheese: What cheese would you like?'''\n",
+    "    \n",
+    "    time = %timeit -o import random\n",
+    "    \n",
     "    return {'response':\"I'm afraid we're fresh out of {}, Sir.\".format(cheese)}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
    "metadata": {
     "scrolled": true
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "89.6 ns ± 0.528 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "{'response': \"I'm afraid we're fresh out of cheddar, Sir.\"}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tranquilizer/__init__.py
+++ b/tranquilizer/__init__.py
@@ -1,4 +1,4 @@
 '''Tranquilizer'''
 from .decorator import tranquilize
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'

--- a/tranquilizer/__main__.py
+++ b/tranquilizer/__main__.py
@@ -2,16 +2,25 @@ import sys
 from os.path import dirname, basename
 
 from .application import make_app, cli
-from .handler import get_tranquilized_functions
+from .handler import ScriptHandler, NotebookHandler
+
+class UnsupportedFileType(Exception):
+    pass
 
 def main():
     args = cli().parse_args()
     sys.path.append(dirname(args.filename))
 
-    functions = get_tranquilized_functions(args.filename)
+    extension = args.filename.split('.')[-1]
+    if extension == 'py':
+        source = ScriptHandler(args.filename)
+    elif extension == 'ipynb':
+        source = NotebookHandler(args.filename)
+    else:
+        raise UnsupportedFileType('{} is not a script (.py) or notebook (.ipynb)'.format(args.filename))
 
     name = args.name if args.name else basename(args.filename)
-    app = make_app(functions, name=name, prefix=args.anaconda_project_url_prefix)
+    app = make_app(source.tranquilized_functions, name=name, prefix=args.anaconda_project_url_prefix)
 
     app.run(host=args.anaconda_project_address, port=args.anaconda_project_port,
             debug=args.debug)

--- a/tranquilizer/handler.py
+++ b/tranquilizer/handler.py
@@ -1,30 +1,62 @@
 '''execute the script file'''
 import ast
 from runpy import run_path
-
-def _parse_script(fn):
-    with open(fn, 'r') as f:
-        source = f.read()
-
-    nodes = ast.parse(source, fn)
-    return nodes
-
+from abc import ABC, abstractmethod
+from os.path import dirname, join, basename
+import os
 
 def _is_tranquilized(decorator):
     return hasattr(decorator, 'id') and (decorator.id in ('tranquilize',))
-
 
 def _is_decorated(item):
     if isinstance(item, ast.FunctionDef):
         return any([_is_tranquilized(d.func) for d in item.decorator_list])
 
+class BaseHandler(object):
 
-def get_tranquilized_functions(fn):
-    nodes = _parse_script(fn)
-    tranquilized = [f.name for f in nodes.body if _is_decorated(f)]
+    def parse(self):
+        raise NotImplementedError()
 
-    module = run_path(fn)
-    funcs = [module[f] for f in tranquilized]
+    @property
+    def tranquilized_functions(self):
+        self.parse()
 
-    return funcs
+        tranquilized = [f.name for f in self.nodes.body if _is_decorated(f)]
+        functions = [self.module[f] for f in tranquilized]
+    
+        return functions
 
+
+class ScriptHandler(BaseHandler):
+    def __init__(self, fn):
+        self.fn = fn
+
+    def parse(self):
+        with open(self.fn, 'r') as f:
+            source = f.read()
+
+        self.nodes = ast.parse(source, self.fn)
+        self.module = run_path(self.fn)
+
+
+class NotebookHandler(BaseHandler):
+    def __init__(self, fn):
+        self.fn = fn
+    
+    def parse(self):
+        from nbconvert import ScriptExporter
+
+        exporter = ScriptExporter()
+        source, _ = exporter.from_filename(self.fn)
+
+        #maybe not the best idea, but works
+        directory = dirname(self.fn)
+        script_name = basename(self.fn) + '.py'
+        script_file = join(directory, script_name)
+        with open(script_file, 'w') as f:
+            f.write(source)
+
+        self.nodes = ast.parse(source, script_file)
+        self.module = run_path(script_file)
+
+        os.remove(script_file)

--- a/tranquilizer/handler.py
+++ b/tranquilizer/handler.py
@@ -2,6 +2,7 @@
 import ast
 from runpy import run_path
 from abc import ABC, abstractmethod
+from unittest.mock import MagicMock
 from os.path import dirname, join, basename
 import os
 
@@ -57,6 +58,6 @@ class NotebookHandler(BaseHandler):
             f.write(source)
 
         self.nodes = ast.parse(source, script_file)
-        self.module = run_path(script_file)
+        self.module = run_path(script_file, init_globals={'get_ipython':MagicMock()})
 
         os.remove(script_file)


### PR DESCRIPTION
REST APIs can be served from Jupyter Notebooks with the exception that all magic (`%`) and shell commands (`!`) are completely ignored.

When working interactively in the notebook decorated functions will continue to operate without modification. The decorator just adds a few attributed that are picked up by the `tranquilizer` executable.


Thanks @ericdill for suggesting MagicMock.

