### PR TITLE
switch to flask-RESTX for werkzeug-1.0.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ def order(cheese):
     return "I'm afraid we're fresh out of {}, Sir.".format(cheese)
 ```
 
-The REST API is served by [Flask](http://flask.pocoo.org/) and [Flask-RESTPlus](http://flask-restplus.readthedocs.io/en/stable/index.html)
+The REST API is served by [Flask](http://flask.pocoo.org/) and [Flask-RESTX](https://flask-restx.readthedocs.io/en/latest/)
 using the `tranquilizer` command.
 
 
@@ -96,7 +96,7 @@ provides specialized support for Lists, date/datetime, and files.
 |`typing.List[<type>]`| Converts *repeated* arguments to a list; each value is converted to `<type>`.|
 
 `List` arguments are constructed using the `action='append'` argument described in
-the [Flask RESTPlus documentation](http://flask-restplus.readthedocs.io/en/stable/parsing.html#multiple-values-lists).
+the [Flask RESTX documentation](https://flask-restx.readthedocs.io/en/stable/parsing.html#multiple-values-lists).
 Any valid type can be used in `List[]`.
 
 The following file-like types are handled by [werkzeug `FileStorage`](http://werkzeug.pocoo.org/docs/0.14/datastructures/#werkzeug.datastructures.FileStorage).

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
    - flask
    - werkzeug >=0.15, <1.0
    - python-dateutil
-   - flask-restplus
+   - flask-restx
   build:
    - python >=3.5, <3.8
    - setuptools

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,11 +19,11 @@ requirements:
   run:
    - python >=3.5, <3.9
    - flask
-   - werkzeug >=0.15, <1.0
+   - werkzeug >=0.15, <2.0
    - python-dateutil
    - flask-restx
   build:
-   - python >=3.5, <3.8
+   - python >=3.5, <3.9
    - setuptools
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open("README.md", "r") as fh:
 
 install_requires=[
     'flask',
-    'werkzeug>=0.15,<1.0',
-    'flask-restplus',
+    'werkzeug>=0.15,<2.0',
+    'flask-restx',
     'python-dateutil'
 ]
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -2,7 +2,7 @@ from tranquilizer.resource import  make_resource, make_parser
 from tranquilizer.handler import ScriptHandler
 from tranquilizer.decorator import publish, tranquilize
 from tranquilizer.types import is_list_subclass
-from flask_restplus import Resource, Namespace
+from flask_restx import Resource, Namespace
 import typing
 import datetime
 import numpy

--- a/tranquilizer/application.py
+++ b/tranquilizer/application.py
@@ -11,7 +11,7 @@ def make_app(functions, name, prefix='/', max_content_length=None):
     if max_content_length is not None:
         app.config['MAX_CONTENT_LENGTH'] = max_content_length
     app.wsgi_app = ProxyFix(app.wsgi_app,
-                            num_proxies=None,
+                            # num_proxies=None,
                             x_for=1, x_proto=1,
                             x_host=1, x_port=1,
                             x_prefix=1)

--- a/tranquilizer/application.py
+++ b/tranquilizer/application.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
-from flask_restplus import Api, Namespace
+from flask_restx import Api, Namespace
 
 from .resource import make_resource
 

--- a/tranquilizer/resource.py
+++ b/tranquilizer/resource.py
@@ -1,6 +1,6 @@
-'''construct flask-restplus resources'''
+'''construct flask-restx resources'''
 from flask import jsonify
-from flask_restplus import Resource, reqparse
+from flask_restx import Resource, reqparse
 from collections import Mapping, Sequence
 from typing import List
 

--- a/tranquilizer/resource.py
+++ b/tranquilizer/resource.py
@@ -1,7 +1,7 @@
 '''construct flask-restx resources'''
 from flask import jsonify
 from flask_restx import Resource, reqparse
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing import List
 
 from .types import is_container, type_mapper

--- a/tranquilizer/types.py
+++ b/tranquilizer/types.py
@@ -3,8 +3,8 @@ from dateutil.parser import parse
 from datetime import datetime, date
 from typing import TextIO, BinaryIO
 from werkzeug.datastructures import FileStorage
-from flask_restplus.reqparse import PY_TYPES
-from flask_restplus import fields
+from flask_restx.reqparse import PY_TYPES
+from flask_restx import fields
 import io
 
 def is_container(type_):
@@ -104,7 +104,7 @@ def list_factory(type_):
     items = getattr(type_, '__schema__', {}).get('type', PY_TYPES.get(type_, 'string'))
 
     class TypedList(Sequence):
-        # using append with flask-restplus
+        # using append with flask-restx
         # means that list is constructed later
         __schema__ = {'type': items}
         __description__ = 'List with values of type {}'.format(items)


### PR DESCRIPTION
It's a mechanical switch, but I hope it should be ok.